### PR TITLE
Refactored `nextflow.config` file using *profiles*

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,12 +36,10 @@ docker pull satta/annot-nf
 
 Here's how to start an example run using Docker (using the example dataset and parameterization included in the distribution):
 ```
-$ git clone https://github.com/satta/annot-nf.git
-$ cd annot-nf
-$ nextflow -c loc_docker.config -c params_default.config run annot.nf
+$ nextflow run sanger-pathogens/annot-nf -profile docker
 ```
 
-For your own runs, clone `params_default.config` and substitute your own file names, paths, parameters, etc.
+For your own runs, provide your own file names, paths, parameters, etc. as defined in the `nextflow.config` file.
 
 ### [Preparing reference annotations](#reference)
 

--- a/nextflow.config
+++ b/nextflow.config
@@ -3,3 +3,64 @@ manifest {
     description = 'Kinetoplastid annotation pipeline'
     mainScript = 'annot.nf'
 }
+
+params {
+    // input sequence
+    inseq = "${baseDir}/example-data/L_donovani.fasta.1"
+
+    // reference data -- paths must be absolute
+    ref_dir = "${baseDir}/example-data/references"
+    ref_species = "LmjF.1"
+
+    // output directory, if desired
+    // dist_dir = "${baseDir}"
+
+    // enable/disable parts of the pipeline
+    run_exonerate    = false
+    do_contiguation  = true
+    do_circos        = true
+    make_embl        = true
+    use_reference    = true
+
+    // naming patterns
+    GENOME_PREFIX = "LDON"
+    CHR_PATTERN = "LDON_(%d+)"
+    MAX_GENE_LENGTH = 20000
+    ABACAS_CHR_PATTERN = 'LmjF.(%d+)'
+    ABACAS_CHR_PREFIX = "LDON"
+    ABACAS_SEQ_PREFIX = "LDON"
+    ABACAS_BIN_CHR = "LDON_0"
+
+    // RATT parameters
+    RATT_TRANSFER_TYPE = 'Species'
+
+    // AUGUSTUS parameters
+    AUGUSTUS_SPECIES = 'leishmania_major_sampled'
+    AUGUSTUS_GENEMODEL = 'intronless'
+    AUGUSTUS_HINTS_MAXINTRONLEN = '1'
+    AUGUSTUS_SCORE_THRESHOLD = 0.7
+
+    // EMBL file metadata
+    EMBL_AUTHORS = "Foo Bar"
+    EMBL_TITLE = "Baz"
+    EMBL_PUBLICATION = "Quux"
+    EMBL_GENOME_TYPE = "XXX"
+    EMBL_CLASSIFICATION = "XXXX"
+    EMBL_ORGANISM = "Leishmania donovani"
+    EMBL_PROJ_ACCESSION = "123456"
+    EMBL_DESCRIPTION = "Foo bar"
+
+    // output GAF metadata
+    TAXON_ID = 4711
+    DB_ID = "GeneDB"
+    
+}
+
+profiles {
+
+	docker { includeConfig 'loc_docker.config' }
+	sanger { includeConfig 'loc_sanger.config' }
+	sanger_farm { includeConfig 'loc_sanger_farm.config' }
+	travis { includeConfig 'loc_travis.config' }
+	
+}


### PR DESCRIPTION
You may be interested in this pull request. The main config file contains all the default params. It also defines some profiles including the external config files. 

Also note the use of `baseDir` variable that replace your custom var `ROOTDIR`. The `baseDir` is an implicit variable that refers to the folder where the main nextflow script is located. 

The benefit of this approach is that you can run the pipeline without having to clone it previously, by simply using this command:  

    nextflow run sanger-pathogens/annot-nf <your pipeline options>


note: it requires latest version 0.14.2 (due to a bug in the config file include mechanism) 