### PR TITLE
add tantan, make PTU smoothing optional

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -92,6 +92,19 @@ RUN cd /opt && \
     chmod 755 /usr/bin/Gblocks
 
 #
+# Install tantan
+#
+ADD http://cbrc3.cbrc.jp/~martin/tantan/tantan-13.zip /opt/tantan-13.zip
+RUN cd /opt && \
+    unzip tantan-13.zip && \
+    rm -rf tantan-13.zip && \
+    cd tantan-13 && \
+    make -j2 && \
+    make install && \
+    cd .. && \
+    rm -rf tantan-13
+
+#
 # get GO OBO file
 #
 ADD http://geneontology.org/ontology/go.obo /opt/go.obo

--- a/annot.nf
+++ b/annot.nf
@@ -433,10 +433,9 @@ process pseudogene_indexing {
     file 'prot_index*' into pseudochr_last_index
 
     """
-    lastdb -p prot_index ref.peps.fasta
+    tantan -p -r0.02 ref.peps.fasta | lastdb -p -c prot_index
     """
 }
-
 
 pseudochr_seq_pseudogene.into{ pseudochr_seq_pseudogene_align; pseudochr_seq_pseudogene_calling }
 pseudochr_seq_pseudogene_align.splitFasta( by: 3 ).set { pseudogene_align_chunk }
@@ -450,7 +449,7 @@ process pseudogene_last {
     file 'last.out' into pseudochr_last_out
 
     """
-    lastal -pBL80 -F15 -e300 -m100 -f0 prot_index chunk.fasta > last.out
+    lastal -pBL80 -F15 -e100 -m10 -f0 prot_index chunk.fasta > last.out
     """
 }
 

--- a/annot.nf
+++ b/annot.nf
@@ -104,7 +104,7 @@ scaffolds_agp.into{ scaffolds_agp_augustus
 					scaffolds_agp_make_gaps
                     scaffolds_agp_make_dist }
 
-pseudochr_agp.into{ pseudochr_agp_augustus 
+pseudochr_agp.into{ pseudochr_agp_augustus
 				    pseudochr_agp_make_gaps
                     pseudochr_agp_make_dist }
 
@@ -860,7 +860,7 @@ process make_distribution_seqs {
 
 result_seq.into{ stats_inseq
 				 circos_inseq
-				 report_inseq 
+				 report_inseq
 				 out_seq
 				 embl_inseq }
 
@@ -868,7 +868,7 @@ result_seq.into{ stats_inseq
 result_gff3.into{ stats_gff3
 				  circos_gff3
 				  report_gff3
-				  out_gff3 
+				  out_gff3
 				  embl_gff3
                   refcomp_gff3_in
                   genelist_gff3_in
@@ -1026,7 +1026,7 @@ if (params.do_contiguation && params.do_circos) {
 
     ref_target_mapping.splitCsv(sep: "\t").set { circos_chromosomes }
     circos_conffile = file(params.CIRCOS_CONFIG_FILE)
-    
+
     process circos_run_chrs {
         tag { chromosome[0] }
 
@@ -1051,7 +1051,7 @@ if (params.do_contiguation && params.do_circos) {
 
     bin_target_mapping.splitCsv(sep: "\t").set { circos_binmap }
     circos_binconffile = file(params.CIRCOS_BIN_CONFIG_FILE)
-    
+
     process circos_run_bin {
         // this process can fail
         errorStrategy 'ignore'

--- a/nextflow.config
+++ b/nextflow.config
@@ -21,6 +21,7 @@ params {
     do_circos        = true
     make_embl        = true
     use_reference    = true
+    fix_polycistrons = true
 
     // naming patterns
     GENOME_PREFIX = "LDON"

--- a/test/travis.setup-last.sh
+++ b/test/travis.setup-last.sh
@@ -9,3 +9,13 @@ make install
 cd ..
 rm -rf last-581
 rm -f last-581.zip
+
+rm -f tantan-13.zip
+wget -q http://cbrc3.cbrc.jp/~martin/tantan/tantan-13.zip
+unzip tantan-13.zip
+cd ltantan-13
+make
+make install
+cd ..
+rm -rf tantan-13
+rm -f tantan-13.zip

--- a/test/travis.setup-last.sh
+++ b/test/travis.setup-last.sh
@@ -13,7 +13,7 @@ rm -f last-581.zip
 rm -f tantan-13.zip
 wget -q http://cbrc3.cbrc.jp/~martin/tantan/tantan-13.zip
 unzip tantan-13.zip
-cd ltantan-13
+cd tantan-13
 make
 make install
 cd ..


### PR DESCRIPTION
This PR adds tandem repeat masking on proteins used for LAST runs in pseudogene detection. It also adds a parameter `fix_polycistrons` enabling the PTU smoothing step after gene model integration. This is on by default but this parameter allows one to switch it off for organisms with no PTU organisation (e.g. _Plasmodium_).