### PR TITLE
simplify and improve EMBL export for RATT

### DIFF
--- a/annot.nf
+++ b/annot.nf
@@ -237,17 +237,14 @@ if (params.run_exonerate) {
 process ratt_make_ref_embl {
     input:
     file ref_annot
-    file ref_seq
+    file ref_chr
     val go_obo
 
     output:
     file '*.embl' into ref_embl
 
     """
-    # make sure GFF3 contains sequence
-    gt inlineseq_split -seqfile /dev/null -gff3file ref_without_seq.gff3 ${ref_annot}
-    gt inlineseq_add -seqfile ${ref_seq} -matchdescstart ref_without_seq.gff3 > ref_with_seq.gff3
-    gff3_to_embl.lua ref_with_seq.gff3 ${go_obo} Foo ${ref_seq}
+    gff3_to_embl.lua -o ${ref_annot} ${go_obo} Foo ${ref_chr}
     """
 }
 


### PR DESCRIPTION
RATT takes ages when handed a lot of reference sequences, e.g. in _T. cruzi_, most of which don't carry any annotation. This PR changes the pipeline to only use the chromosome sequences as specified in the reference directory, and adds the `-o` switch to `gff3_to_embl.lua` which makes the the tool ignore all features which don' t have a sequence in the chromosome file -- otherwise this would cause an error.