### PR TITLE
clean up after RATT

### DIFF
--- a/annot.nf
+++ b/annot.nf
@@ -325,6 +325,8 @@ if (params.TRANSCRIPT_FILE) {
 
 combined_hints = exn_hints.concat(trans_hints)
 process merge_hints {
+    cache 'deep'
+
     input:
     file 'hints.concatenated.txt' from combined_hints.collectFile()
 

--- a/annot.nf
+++ b/annot.nf
@@ -261,6 +261,8 @@ process ratt_make_ref_embl {
 }
 
 process run_ratt {
+    afterScript 'rm -rf Reference* Sequences Query query.*'
+
     input:
     file 'in*.embl' from ref_embl
     file 'pseudo.pseudochr.fasta' from pseudochr_seq_ratt


### PR DESCRIPTION
On some machines (e.g. a web app server), one might only have little scratch space. This PR cleans up the intermediate output of RATT, which keeps copies of input sequences and other temporary files we don't use afterwards.