### PR TITLE
make sure to fix ownership on Docker

### DIFF
--- a/loc_docker.config
+++ b/loc_docker.config
@@ -21,6 +21,7 @@ process {
 
 docker {
     enabled = true
+    fixOwnership = true
 }
 
 executor {


### PR DESCRIPTION
On some Docker installations, the `afterScript` directive fails to delete some of the files created by Nextflow processes, resulting in process failure. This is because these files are owned by root. Setting the `docker.fixOwnership` configuration setting to `true` will make sure these files are deletable.