### PR TITLE
make AGP splitting seqid comparisons more stringent

### DIFF
--- a/annot.nf
+++ b/annot.nf
@@ -309,7 +309,8 @@ if (params.TRANSCRIPT_FILE) {
 
     script:
     """
-    LC_ALL='C' sort -k 1,1 -k 4,4n transcripts.gtf | uniq | cufflinks_to_hints.lua > transcripts.hints
+    LC_ALL='C' sort -k 1,1 -k 4,4n transcripts.gtf | uniq | \
+      cufflinks_to_hints.lua > transcripts.hints
     """
   }
 } else {
@@ -479,7 +480,7 @@ process integrate_genemodels {
     file 'integrated.gff3' into integrated_gff3
 
     script:
-    if(params.WEIGHT_FILE.length() > 0)
+    if (params.WEIGHT_FILE.length() > 0)
         """
         integrate_gene_calls.lua -w ${params.WEIGHT_FILE} < merged.gff3 | \
             gt gff3 -sort -tidy -retainids > integrated.gff3
@@ -820,7 +821,6 @@ process annotate_orthologs {
 
     input:
     file 'orthomcl_out' from orthomcl_cluster_out_annot
-   //  file 'mapfile' from full_mapfile
     file 'input.gff3' from genemodels_for_omcl_annot
     file 'gff_ref.gff3' from omcl_gfffile
     file 'gaf_ref.gaf' from omcl_gaffile

--- a/bin/split_gff_by_agp.lua
+++ b/bin/split_gff_by_agp.lua
@@ -88,8 +88,8 @@ hdrcache = {}
 function get_real_seqhdr(hdr)
   if not hdrcache[hdr] then
     for _,v in ipairs(tkeys) do
+      v = v:split("%s")[1]
       if v == hdr then
-        v = v:split("%s")[1]
         hdrcache[hdr] = v
         return v
       end

--- a/bin/split_gff_by_agp.lua
+++ b/bin/split_gff_by_agp.lua
@@ -30,8 +30,6 @@ end
 
 package.path = gt.script_dir .. "/?.lua;" .. package.path
 require("lib")
---require("cliargs")
-local lfs = require("lfs")
 
 gff = arg[1]
 agp = arg[2]
@@ -90,7 +88,7 @@ hdrcache = {}
 function get_real_seqhdr(hdr)
   if not hdrcache[hdr] then
     for _,v in ipairs(tkeys) do
-      if v:match(hdr) then
+      if v == hdr then
         v = v:split("%s")[1]
         hdrcache[hdr] = v
         return v


### PR DESCRIPTION
The previous use of `string:match()` to map sequence IDs caused problems when the set of seqids in an AGP file is not substring-free. This is problematic in input data with purely numerical seqids, where seqid `1` would be map to `12` as well. This case appeared in a recent run.
This PR fixes this issue by requiring mapped seqids to be identical up to the first whitespace.