### PR TITLE
some polishing of pipeline output and postprocessing

### DIFF
--- a/annot.nf
+++ b/annot.nf
@@ -553,6 +553,8 @@ process pseudogene_last {
 }
 
 process pseudogene_calling {
+    cache 'deep'
+
     input:
     file 'pseudochr.fasta' from pseudochr_seq_pseudogene_calling
     file 'genes.gff3' from integrated_gff3_clean
@@ -1035,28 +1037,36 @@ if (params.use_reference) {
     }
 
     tree_out.subscribe {
-        println it
+        if (params.print_paths) {
+          println it
+        }
         if (params.dist_dir) {
           it.copyTo(params.dist_dir)
         }
     }
 
     tree_genes.subscribe {
-        println it
+        if (params.print_paths) {
+          println it
+        }
         if (params.dist_dir) {
           it.copyTo(params.dist_dir)
         }
     }
 
     tree_aln.subscribe {
-        println it
+        if (params.print_paths) {
+          println it
+        }
         if (params.dist_dir) {
           it.copyTo(params.dist_dir)
         }
     }
 
     core_comp.subscribe {
-        println it
+        if (params.print_paths) {
+          println it
+        }
         if (params.dist_dir) {
           it.copyTo(params.dist_dir)
         }
@@ -1179,14 +1189,18 @@ if (params.do_contiguation && params.do_circos) {
     }
 
     circos_output.subscribe {
-        println it[0]
+        if (params.print_paths) {
+          println it[0]
+        }
         if (params.dist_dir) {
           it[0].copyTo(params.dist_dir + "/chr" + it[1][0] + ".png")
         }
     }
 
     circos_bin_output.subscribe {
-        println it[0]
+        if (params.print_paths) {
+          println it[0]
+        }
         if (params.dist_dir) {
           it[0].copyTo(params.dist_dir + "/chr" + it[1][0] + ".png")
         }
@@ -1228,7 +1242,9 @@ if (params.make_embl) {
     }
 
     embl_out.flatMap().subscribe {
-        println it
+        if (params.print_paths) {
+          println it
+        }
         if (params.dist_dir) {
           it.copyTo(params.dist_dir)
         }
@@ -1272,7 +1288,9 @@ process make_genelist {
 }
 
 genelist_csv_out.subscribe {
-    println it
+    if (params.print_paths) {
+      println it
+    }
     if (params.dist_dir) {
       it.copyTo(params.dist_dir)
     }
@@ -1298,7 +1316,9 @@ process add_products_to_protein_fasta {
 // ======
 
 out_gff3.subscribe {
-    println it
+    if (params.print_paths) {
+      println it
+    }
     if (params.dist_dir) {
       for (file in it) {
         file.copyTo(params.dist_dir)
@@ -1307,7 +1327,9 @@ out_gff3.subscribe {
 }
 
 out_seq.subscribe {
-    println it
+    if (params.print_paths) {
+      println it
+    }
     if (params.dist_dir) {
       for (file in it) {
         file.copyTo(params.dist_dir)
@@ -1316,7 +1338,9 @@ out_seq.subscribe {
 }
 
 result_agp.subscribe {
-    println it
+    if (params.print_paths) {
+      println it
+    }
     if (params.dist_dir) {
       for (file in it) {
         file.copyTo(params.dist_dir)
@@ -1325,35 +1349,45 @@ result_agp.subscribe {
 }
 
 result_gaf.collectFile().subscribe {
-    println it
+    if (params.print_paths) {
+      println it
+    }
     if (params.dist_dir) {
       it.copyTo(params.dist_dir)
     }
 }
 
 result_ortho.collectFile().subscribe {
-    println it
+    if (params.print_paths) {
+      println it
+    }
     if (params.dist_dir) {
       it.copyTo(params.dist_dir)
     }
 }
 
 result_protein.subscribe {
-    println it
+    if (params.print_paths) {
+      println it
+    }
     if (params.dist_dir) {
       it.copyTo(params.dist_dir)
     }
 }
 
 stats_output.subscribe {
-    println it
+    if (params.print_paths) {
+      println it
+    }
     if (params.dist_dir) {
       it.copyTo(params.dist_dir)
     }
 }
 
 report_output.subscribe {
-    println it
+    if (params.print_paths) {
+      println it
+    }
     if (params.dist_dir) {
       for (file in it) {
         file.copyTo(params.dist_dir)

--- a/bin/create_polypeptides.lua
+++ b/bin/create_polypeptides.lua
@@ -48,7 +48,11 @@ function cv:visit_feature(fn)
   local chr = "00"
   m = seqid:match(arg[3])
   if m then
-    chr = m
+    if tonumber(m) then
+      chr = string.format("%02d", tonumber(m))
+    else
+      chr = m
+    end
   end
   -- initialize counter for feature numbers
   if not self.numbers[chr] then

--- a/bin/stream_new_against_core.lua
+++ b/bin/stream_new_against_core.lua
@@ -162,9 +162,9 @@ treegenes = io.open("tree_selection.genes", "w+")
 for _,cl in ipairs(global_core_clusters) do
   local seen_species = {}
   for _,m in ipairs(cl.members) do
-    if not seen_species[m[2]] then
+    local seq = prots[m[2]][m[1]]
+    if not seen_species[m[2]] and seq then
       seen_species[m[2]] = true
-      local seq = prots[m[2]][m[1]]
       treegenes:write(m[1] .. "\t")
       specseqs[m[2]] = specseqs[m[2]] .. seq
     end

--- a/bin/update_references.lua
+++ b/bin/update_references.lua
@@ -350,6 +350,8 @@ for name, values in pairs(refs.species) do
   -- prepare GAF
   if file_exists(values.gaf) then
     os.execute("cp " .. values.gaf .. " " .. name .. "/go.gaf")
+  else
+    io.stderr:write("warning: GAF for " .. name .. " does not exist in " .. values.gaf .. "\n")
   end
   values.gaf = nil -- lfs.currentdir() .. "/" .. name .. "/go.gaf"
 
@@ -411,7 +413,7 @@ for name, values in pairs(refs.species) do
   end
   ggfile:write("\n")
   if file_exists(name .. "/proteins_preclean.fasta") then
-    --os.remove(name .. "/proteins_preclean.fasta")
+    os.remove(name .. "/proteins_preclean.fasta")
   end
   values.pep = nil -- lfs.currentdir() .. "/" .. name .. "/proteins.fasta"
 

--- a/data/speck/output_check.lua
+++ b/data/speck/output_check.lua
@@ -49,7 +49,7 @@ describe.feature("gene", function(gene)
               "Start_range", "Dbxref", "controlled_curation",
               "previous_systematic_id", "fiveEndPartial", "threeEndPartial",
               "literature", "synonym", "eupathdb_uc",
-              "internalGap"}).should_contain(k)
+              "internalGap", "ratt_ortholog"}).should_contain(k)
     end
   end)
 
@@ -110,7 +110,10 @@ describe.feature("pseudogene", function(pseudogene)
       expect({"ID", "Name", "comment", "Note", "End_range",
               "Start_range", "Dbxref", "controlled_curation",
               "previous_systematic_id", "literature",
-              "synonym", "eupathdb_uc"}).should_contain(k)
+              "synonym", "eupathdb_uc", "has_internal_stop",
+              "has_frameshift", "has_start", "has_stop",
+              "original_prot_length", "Target",
+              "ratt_ortholog"}).should_contain(k)
     end
   end)
 
@@ -392,7 +395,7 @@ describe.feature("polypeptide", function(pp)
               "polypeptide_domain", "product", "product_synonym",
               "signal_peptide", "similarity",
               "stop_codon_redefined_as_selenocysteine",
-              "translation"}).should_contain(k)
+              "translation", "ortholog_cluster"}).should_contain(k)
     end
   end)
 
@@ -504,7 +507,8 @@ describe.feature("tRNA", function(node)
       expect({"ID", "Name", "Parent", "comment", "Note", "Start_range",
               "End_range",  "Dbxref", "controlled_curation", "product",
               "product_synonym", "previous_systematic_id",
-              "literature", "Ontology_term"}).should_contain(k)
+              "literature", "Ontology_term", "aa", "anticodon",
+              "gc_content"}).should_contain(k)
     end
   end)
 
@@ -524,7 +528,8 @@ describe.feature("rRNA", function(node)
       expect({"ID", "Name", "Parent", "comment", "Note", "Start_range",
               "End_range",  "Dbxref", "controlled_curation", "product",
               "product_synonym", "previous_systematic_id",
-              "literature", "Ontology_term"}).should_contain(k)
+              "literature", "Ontology_term", "model_name", "model_range",
+              "gc", "evalue", "score"}).should_contain(k)
     end
   end)
 
@@ -544,7 +549,9 @@ describe.feature("snRNA", function(node)
       expect({"ID", "Name", "Parent", "comment", "Note", "Start_range",
               "End_range",  "Dbxref", "controlled_curation", "product",
               "product_synonym", "previous_systematic_id",
-              "literature", "internalGap", "Ontology_term"}).should_contain(k)
+              "literature", "internalGap", "Ontology_term",
+              "model_name", "model_range",
+              "gc", "evalue", "score"}).should_contain(k)
     end
   end)
 
@@ -564,7 +571,8 @@ describe.feature("snoRNA", function(node)
       expect({"ID", "Name", "Parent", "comment", "Note", "Start_range",
               "End_range",  "Dbxref", "controlled_curation", "product",
               "product_synonym", "previous_systematic_id",
-              "literature", "Ontology_term"}).should_contain(k)
+              "literature", "Ontology_term", "model_name", "model_range",
+              "gc", "evalue", "score"}).should_contain(k)
     end
   end)
 


### PR DESCRIPTION
This PR adds the following features:
 - full paths to result files are not printed to stdout unless `--print_paths` is given in order not to clutter regular log output 
 - additional attributes in output GFF are permitted now
 - missing genes in reference annotations when trying to find core genes for tree building do not cause the pipeline to exit, but rather emit a warning and continue trying with other core members
 - only numeric chromosome IDs are formatted with leading zeroes