### PR TITLE
fixes and improvements

### DIFF
--- a/ABACAS2/TilingGraph.pm
+++ b/ABACAS2/TilingGraph.pm
@@ -969,7 +969,7 @@ sub buildOverlap
 
 #  print Dumper $$ref_contigSeq{$actualContig};
 
-  my $contigLength=(scalar(@{$$ref_contigSeq{$actualContig}})-1);
+  my $contigLength=(scalar(@{$$ref_contigSeq{$actualContig}}));
 
   my $ref_cont=\@{$$ref_contigSeq{$actualContig}};
 

--- a/ABACAS2/abacas2.advanced.sh
+++ b/ABACAS2/abacas2.advanced.sh
@@ -7,10 +7,6 @@ ABA_MIN_IDENTITY=$4
 doBlast=$5
 MemBig=$6
 
-PERL5LIB=$PERL5LIB:/software/badger/lib/perl5:/software/pathogen/psu_svn/trunk/genlib/perl/src:/software/pathogen/external/lib/site_perl:/software/pathogen/external/lib/perl:/software/pathogen/external/lib/perl/lib:/software/pathogen/external/lib/perl/lib/site_perl:/software/pathogen/external/lib/perl5:/software/pubseq/PerlModules/Modules:/software/badger/lib/perl5:/software/noarch/badger/lib/perl5:/nfs/users/nfs_t/tdo/bin/oldPerl:/nfs/users/nfs_t/tdo/pathogen/user/mh12/perl/lib:/software/pathogen/projects/protocols/lib/perl5
-
-export PERL5LIB
-
 if [ -z "$contig" ] ; then
 	echo "
 
@@ -31,14 +27,14 @@ ABA_CHECK_OVERLAP=0; export ABA_CHECK_OVERLAP # this will not try to overlap con
 ABA_splitContigs=1; export ABA_splitContigs # this parameter will split contigs. This is good to split the orign, and to find rearrangement. A split contigs has the suffix _i (i the part)
 ABA_WORD_SIZE  # sets the word size. This is critical for speed issues in nucmer. default is 20
 "
-	
+
 exit;
 fi
 
-if [ -z "$ABA_MIN_LENGTH" ] ; then 
+if [ -z "$ABA_MIN_LENGTH" ] ; then
 	ABA_MIN_LENGTH=200;
 fi
-if [ -z "$ABA_MIN_IDENTITY" ] ; then 
+if [ -z "$ABA_MIN_IDENTITY" ] ; then
 	ABA_MIN_IDENTITY=95;
 fi
 if [ -z "$MemBig" ]; then
@@ -63,15 +59,15 @@ tmp=$$
 
 
 #do ordering
-for x in `grep '>' $reference | perl -nle '/>(\S+)/;print $1' ` ;       
-  do 
+for x in `grep '>' $reference | perl -nle '/>(\S+)/;print $1' ` ;
+  do
 #  echo " bsub -w\"stage1.$tmp\" -J\"stage2.$tmp\" -R \"select[type==X86_64 && mem > $MemBig] rusage[mem=$MemBig]\" -M\"$MemBig\"000 -o output2.$x.o -e output2.$x.e \"~tdo/Bin/goTilingGraph.pl $x.coords  $contig Res\";"
 
   if [ -f "$x.coords" ] ; then
   bsub  -J"stage2.$tmp" -R "select[type==X86_64 && mem > $MemBig] rusage[mem=$MemBig]" -M"$MemBig"000 -o output2.$x.o -e output2.$x.e "~tdo/Bin/goTilingGraph.pl $x.coords  $contig Res";
   fi
 
-done 
+done
 
 
 #do bin

--- a/ABACAS2/abacas2.doTilingGraph.pl
+++ b/ABACAS2/abacas2.doTilingGraph.pl
@@ -13,12 +13,11 @@
 
 use strict;
 
-use lib '/nfs/pathogen003/tdo/Tools/ABACAS2';
 use TilingGraph;
 
 if (scalar(@ARGV) < 3) {
   die "Usage: coords sequence Resultname\n";
-  
+
 }
 TilingGraph::startTiling(shift,shift,shift);
 

--- a/ABACAS2/abacas2.fill.sh
+++ b/ABACAS2/abacas2.fill.sh
@@ -7,10 +7,6 @@ ABA_MIN_IDENTITY=$4
 doBlast=$5
 MemBig=$6
 
-PERL5LIB=$PERL5LIB:/software/badger/lib/perl5:/software/pathogen/psu_svn/trunk/genlib/perl/src:/software/pathogen/external/lib/site_perl:/software/pathogen/external/lib/perl:/software/pathogen/external/lib/perl/lib:/software/pathogen/external/lib/perl/lib/site_perl:/software/pathogen/external/lib/perl5:/software/pubseq/PerlModules/Modules:/software/badger/lib/perl5:/software/noarch/badger/lib/perl5:/nfs/users/nfs_t/tdo/bin/oldPerl:/nfs/users/nfs_t/tdo/pathogen/user/mh12/perl/lib:/software/pathogen/projects/protocols/lib/perl5
-
-export PERL5LIB
-
 if [ -z "$contig" ] ; then
 	echo "
 
@@ -31,14 +27,14 @@ ABA_CHECK_OVERLAP=0; export ABA_CHECK_OVERLAP # this will not try to overlap con
 ABA_splitContigs=1; export ABA_splitContigs # this parameter will split contigs. This is good to split the orign, and to find rearrangement. A split contigs has the suffix _i (i the part)
 ABA_WORD_SIZE  # sets the word size. This is critical for speed issues in nucmer. default is 20
 "
-	
+
 exit;
 fi
 
-if [ -z "$ABA_MIN_LENGTH" ] ; then 
+if [ -z "$ABA_MIN_LENGTH" ] ; then
 	ABA_MIN_LENGTH=200;
 fi
-if [ -z "$ABA_MIN_IDENTITY" ] ; then 
+if [ -z "$ABA_MIN_IDENTITY" ] ; then
 	ABA_MIN_IDENTITY=95;
 fi
 if [ -z "$MemBig" ]; then
@@ -70,11 +66,11 @@ bsub -J"stage1.$tmp"  -w"stage0.$tmp" -R "select[type==X86_64 && mem > 8000] rus
 
 
 #do ordering
-for x in `grep '>' $reference | perl -nle '/>(\S+)/;print $1' ` ;       
-  do 
+for x in `grep '>' $reference | perl -nle '/>(\S+)/;print $1' ` ;
+  do
 #  echo " bsub -w\"stage1.$tmp\" -J\"stage2.$tmp\" -R \"select[type==X86_64 && mem > $MemBig] rusage[mem=$MemBig]\" -M\"$MemBig\"000 -o output2.$x.o -e output2.$x.e \"~tdo/Bin/goTilingGraph.pl $x.coords  $contig Res\";"
   bsub -w"stage1.$tmp" -J"stage2.$tmp" -R "select[type==X86_64 && mem > $MemBig] rusage[mem=$MemBig]" -M"$MemBig"000 -o output2.$x.o -e output2.$x.e "~tdo/Bin/goTilingGraph.pl $x.coords  $contig Res";
-done 
+done
 
 
 #do bin

--- a/annot.nf
+++ b/annot.nf
@@ -365,6 +365,7 @@ process merge_hints {
     set stdout, file('hints.txt') into all_hints
 
     """
+    touch hints.txt
     cat hints.exon.txt hints.trans.txt > hints.concatenated.txt
     if [ -s hints.concatenated.txt ] ; then mv hints.concatenated.txt hints.txt; echo -n '--hintsfile=augustus.hints'; fi
     """

--- a/bin/abacas_combine.lua
+++ b/bin/abacas_combine.lua
@@ -60,9 +60,12 @@ for file in lfs.dir(arg[1]) do
           os.exit(1)
         end
         if type1 == "Contig" then
+          local contig_name = attr:match('contig=([^"]+)')
+          assert(contig_name)
           -- this is a 'scaffold'
           this_scaf = {start = start,
                        stop = stop,
+                       name = contig_name,
                        seq = string.sub(seqs[seqid], start, stop),
                        contigs = {}}
           local i_end = 0
@@ -129,6 +132,7 @@ if #binkeys > 0 then
     stop = start + string.len(v) - 1
     this_scaf ={start = tonumber(start),
                 stop = tonumber(stop),
+                name = k,
                 seq = v,
                 contigs = {}}
     local i_end = 0
@@ -172,7 +176,7 @@ for _,seqid in ipairs(newkeys) do
   local i = 1
   local s_last_stop = 0
   for _, s in ipairs(scafs[seqid]) do
-    local scafname = seqprefix .. "_SCAF" .. string.format("%06d", scaf_i)
+    local scafname = tostring(s.name) -- seqprefix .. "_SCAF" .. string.format("%06d", scaf_i)
     scaf_fasta_out:write(">" .. scafname .. "\n")
     print_max_width(s.seq, scaf_fasta_out, 60)
     if s_last_stop > 0 then

--- a/bin/transform_gff_with_agp.lua
+++ b/bin/transform_gff_with_agp.lua
@@ -75,7 +75,7 @@ for l in io.lines(arg[2]) do
         table.insert(gapqueue, fn)
       end
     else
-      mappings[c6:gsub("%.%d+$","")] = {obj=obj, obj_s=tonumber(obj_s),
+      mappings[c6] = {obj=obj, obj_s=tonumber(obj_s),
                                         obj_e=tonumber(obj_e),
                                         s_s=tonumber(c7), s_e=tonumber(c8),
                                         strand=c9}

--- a/bin/transform_gtf_with_agp.lua
+++ b/bin/transform_gtf_with_agp.lua
@@ -1,0 +1,131 @@
+#!/usr/bin/env gt
+
+--[[
+  Copyright (c) 2015 Sascha Steinbiss <ss34@sanger.ac.uk>
+  Copyright (c) 2015 Genome Research Ltd
+
+  Permission to use, copy, modify, and distribute this software for any
+  purpose with or without fee is hereby granted, provided that the above
+  copyright notice and this permission notice appear in all copies.
+
+  THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+  WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+  MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+  ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+  WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+  ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+  OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+]]
+
+function usage()
+  io.stderr:write(string.format("Usage: %s <base GTF> <AGP> "
+                                .. "<base FASTA> <target FASTA> "
+                                .. "[check]\n" , arg[0]))
+  os.exit(1)
+end
+
+if #arg < 2 then
+  usage()
+end
+
+package.path = gt.script_dir .. "/?.lua;" .. package.path
+require("lib")
+
+gff = arg[1]
+agp = arg[2]
+if arg[3] then
+  bkeys, bseqs = get_fasta(arg[3])
+end
+if arg[4] then
+  tkeys, tseqs = get_fasta(arg[4])
+end
+
+function get_seq(seqs, id)
+  for k,v in pairs(seqs) do
+    if k:match("^"..id.."$") then
+      return v
+    end
+  end
+  io.stderr:write("could not find sequence matching object " .. id
+                    .. " in input\n")
+  os.exit(1)
+end
+
+-- load and index AGP
+local mappings = {}
+local lineno = 1
+for l in io.lines(arg[2]) do
+  if string.sub(l, 1, 1) ~= '#' then
+    obj, obj_s, obj_e, part_n, type, c6, c7, c8, c9 = unpack(split(l, "%s+"))
+    if not c6 then
+      error("could not parse line " .. lineno .. "of AGP file " .. arg[2])
+    end
+    if type == 'N' or type == 'U' then
+      -- ignore gaps
+    else
+      mappings[c6] = {obj=obj, obj_s=tonumber(obj_s),
+                                        obj_e=tonumber(obj_e),
+                                        s_s=tonumber(c7), s_e=tonumber(c8),
+                                        strand=c9}
+    end
+  end
+  lineno = lineno + 1
+end
+
+-- process GTF
+lineno = 1
+for l in io.lines(arg[1]) do
+  if string.sub(l, 1, 1) ~= '#' then
+    seqid, src, type, start, stop, score, strand, phase, attrs = unpack(split(l, "\t"))
+    if not attrs then
+      error("could not parse line " .. lineno .. "of GTF file " .. arg[1])
+    end
+    -- is this sequence/fragment part of a layout?
+    if mappings[seqid] then
+      local outstrand = strand
+      local new_rng = nil
+      -- was the fragment used in reverse orientation?
+      if mappings[seqid].strand == "-" then
+        -- transform coordinates for reverse
+        new_rng = gt.range_new((mappings[seqid].s_e - stop + 1)
+                                 + mappings[seqid].obj_s - 1,
+                               (mappings[seqid].s_e - start + 1)
+                                 + mappings[seqid].obj_s - 1)
+        -- flip strands
+        if strand == "+" then
+          outstrand = "-"
+        elseif strand == "-" then
+          outstrand = "+"
+        end
+      else
+        -- otherwise just transform coordinates by offsetting
+        new_rng = gt.range_new(start + mappings[seqid].obj_s - 1,
+                               stop + mappings[seqid].obj_s - 1)
+      end
+      assert(new_rng)
+      assert(outstrand)
+      print(mappings[seqid].obj .. "\t" .. src .. "\t" .. type .. "\t" .. new_rng:get_start() .. "\t" .. new_rng:get_end() .. "\t"
+             .. score .. "\t" .. outstrand .. "\t" .. phase .. "\t" .. attrs)
+      if arg[5] then   -- optionally, check seqs -- must stay the same!
+        seq1 = get_seq(bseqs, seqid):sub(rng:get_start(), rng:get_end())
+        seq2 = get_seq(tseqs, mappings[seqid].obj):sub(new_rng:get_start(),
+                       new_rng:get_end())
+        if  mappings[seqid].strand == "-" then
+          seq2 = revcomp(seq2)
+        end
+        if seq1 ~= seq2 then
+          print(seq1)
+          print(seq2)
+        end
+        assert(seq1 == seq2)
+      end
+    else
+      -- this sequence is unassembled, do not change its coordinates
+      io.stderr:write("no mapping for seqid " .. seqid .. "\n")
+      --for node in fn:children() do
+      --  node:change_seqid(seqid)
+      --end
+    end
+  end
+  lineno = lineno + 1
+end

--- a/bin/update_references.lua
+++ b/bin/update_references.lua
@@ -271,6 +271,9 @@ end
 
 -- load local 'references.json' file
 local reffile = io.open("references-in.json", "rb")
+if not reffile then
+  error("could not open references-in.json in current directory")
+end
 local refcontent = reffile:read("*all")
 reffile:close()
 refs = json.decode(refcontent)

--- a/loc_sanger.config
+++ b/loc_sanger.config
@@ -1,5 +1,6 @@
 env {
     PATH = "${baseDir}/RATT:${baseDir}/ABACAS2:${HOME}/annot/software/ORTHOMCLV1.4:${HOME}/genometools/bin:/software/pathogen/external/apps/usr/local/tmhmm-2.0c/bin:${HOME}/annot/software/augustus-3.0.3/bin:/software/pathogen/external/apps/usr/bin:$PATH"
+    PERL5LIB = "${baseDir}/ABACAS2:$PERL5LIB"
     RATT_HOME = "${baseDir}/RATT"
     RATT_CONFIG = "${baseDir}/RATT/RATT.config_euk_NoPseudo_SpliceSite"
     GT_RETAINIDS = "yes"

--- a/loc_sanger_farm.config
+++ b/loc_sanger_farm.config
@@ -1,5 +1,6 @@
 env {
     PATH = "${baseDir}/RATT:${baseDir}/ABACAS2:${HOME}/annot/software/ORTHOMCLV1.4:${HOME}/genometools/bin:/software/pathogen/external/apps/usr/local/tmhmm-2.0c/bin:${HOME}/annot/software/augustus-3.0.3/bin:/software/pathogen/external/apps/usr/bin:$PATH"
+    PERL5LIB = "${baseDir}/ABACAS2:$PERL5LIB"
     RATT_HOME = "${baseDir}/RATT"
     RATT_CONFIG = "${baseDir}/RATT/RATT.config_euk_NoPseudo_SpliceSite"
     GT_RETAINIDS = "yes"

--- a/params_default.config
+++ b/params_default.config
@@ -12,6 +12,7 @@ params {
     // enable/disable parts of the pipeline
     run_exonerate    = false
     run_snap         = true
+    run_ratt         = true
     do_contiguation  = true
     do_circos        = true
     make_embl        = true


### PR DESCRIPTION
This PR introduces the following new functionality:
 - an off-by-one error in ABACAS2 is fixed -- this clipped off a base from contiguated scaffolds, causing a shift in coordinates
 - RATT is optional now
 - RNA-seq evidence mapped to the original user scaffolds is now transformed with the ABACAS AGP to match the new pseudochromosome coordinates
 - user scaffold names are not changed but kept in the AGP and scaffold level output
 - small cosmetics and user interaction fixes