### PR TITLE
fixes and improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ work
 trace.csv*
 *.[eo]
 *.i1*
+*_out/

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,7 +29,7 @@ script:
   - cd test/testsuite
   - ./testsuite.rb -threads 2
   - cd ../..
-  - ./nextflow -c loc_travis.config -c params_default.config run annot.nf --do_circos=false
-  - ./nextflow -c loc_travis.config -c params_default.config run annot.nf --do_circos=false --run_exonerate=true
-  - ./nextflow -c loc_travis.config -c params_default.config run annot.nf --do_circos=false --do_pseudo=false
-  - ./nextflow -c loc_travis.config -c params_default.config run annot.nf --do_circos=false --run_snap=false
+  - travis_wait ./nextflow -c loc_travis.config -c params_default.config run annot.nf --do_circos=false
+  - travis_wait ./nextflow -c loc_travis.config -c params_default.config run annot.nf --do_circos=false --run_exonerate=true
+  - travis_wait ./nextflow -c loc_travis.config -c params_default.config run annot.nf --do_circos=false --do_pseudo=false
+  - travis_wait ./nextflow -c loc_travis.config -c params_default.config run annot.nf --do_circos=false --run_snap=false

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ before_install:
   - sudo apt-get -qq update
 
 install:
-  - sudo apt-get install --yes --force-yes circos build-essential wget fasttree hmmer lua5.1 blast2 ncbi-blast+ unzip cpanminus mummer python-setuptools exonerate snap infernal mafft
+  - sudo apt-get install --yes --force-yes circos build-essential wget fasttree hmmer lua5.1 blast2 ncbi-blast+ unzip cpanminus mummer python-setuptools exonerate snap infernal mafft telnet
   - sudo ln -s /usr/bin/fasttree /usr/bin/FastTree
   - sudo test/travis.setup-augustus.sh > /dev/null
   - sudo test/travis.setup-gt.sh > /dev/null

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,4 +29,7 @@ script:
   - cd test/testsuite
   - ./testsuite.rb -threads 2
   - cd ../..
-  - ./nextflow -c loc_travis.config -c params_default.config run annot.nf -resume --do_circos=false
+  - ./nextflow -c loc_travis.config -c params_default.config run annot.nf --do_circos=false
+  - ./nextflow -c loc_travis.config -c params_default.config run annot.nf --do_circos=false --run_exonerate=true
+  - ./nextflow -c loc_travis.config -c params_default.config run annot.nf --do_circos=false --do_pseudo=false
+  - ./nextflow -c loc_travis.config -c params_default.config run annot.nf --do_circos=false --run_snap=false

--- a/ABACAS2/abacas2.nonparallel.sh
+++ b/ABACAS2/abacas2.nonparallel.sh
@@ -68,7 +68,10 @@ for x in `grep '>' $reference | perl -nle '/>(\S+)/;print $1' ` ; do
 	abacas2.doTilingGraph.pl $x.coords  $contig Res
 done
 
-abacas2.bin.sh $contig Res.abacasBin.fna && grep -v '>'  Res.abacasBin.fna | awk 'BEGIN {print ">Bin.union"} {print}' > Res.abacasBin.oneSeq.fna_ && cat Res*fna > Genome.abacas.fasta && bam.correctLineLength.sh Genome.abacas.fasta  &> /dev/null && mv  Res.abacasBin.fna_ Res.abacasBin.fna
+abacas2.bin.sh $contig Res.abacasBin.fna && grep -v '>'  Res.abacasBin.fna | awk 'BEGIN {print ">Bin.union"} {print}' > Res.abacasBin.oneSeq.fna_ && cat Res*fna > Genome.abacas.fasta && bam.correctLineLength.sh Genome.abacas.fasta  &> /dev/null
+if [ -f "Res.abacasBin.fna_" ] ; then
+    mv Res.abacasBin.fna_ Res.abacasBin.fna
+fi
 
 #~tdo/Bin/abacas2.doblast.sh $reference Res
 #ef=$reference

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,7 @@ RUN apt-get update -qq
 RUN apt-get install build-essential hmmer lua5.1 ncbi-blast+ blast2 snap \
                     unzip cpanminus mummer infernal exonerate mafft fasttree \
                     circos libsvg-perl libgd-svg-perl python-setuptools \
-                    libc6-i386 lib32stdc++6 lib32gcc1 \
+                    libc6-i386 lib32stdc++6 lib32gcc1 telnet \
                     last-align --yes --force-yes
 RUN ln -fs /usr/bin/fasttree /usr/bin/FastTree && \
     cpanm --force SVG Carp Storable Bio::SearchIO List::Util \

--- a/annot.nf
+++ b/annot.nf
@@ -276,6 +276,7 @@ if (params.run_ratt) {
         file 'Out*.Report.txt' into ratt_reports
 
         """
+        touch Out.0.Report.txt
         start.ratt.sh . pseudo.pseudochr.fasta Out ${params.RATT_TRANSFER_TYPE}
         """
     }

--- a/annot.nf
+++ b/annot.nf
@@ -1262,6 +1262,8 @@ if (params.make_embl) {
     }
 
     process make_embl {
+        afterScript 'rm -rf 1 1.*'
+
         input:
         file 'embl_in.gff3' from embl_full_gff
         file embl_full_seq
@@ -1271,8 +1273,7 @@ if (params.make_embl) {
         file '*.embl' into embl_out
 
         """
-        zcat ${embl_full_seq} > 1
-        gff3_to_embl.lua -e -o embl_in.gff3 ${go_obo} '${params.EMBL_ORGANISM}' 1 && rm -f 1
+        zcat ${embl_full_seq} > 1 && gff3_to_embl.lua -e -o embl_in.gff3 ${go_obo} '${params.EMBL_ORGANISM}' 1
         """
     }
 

--- a/annot.nf
+++ b/annot.nf
@@ -158,7 +158,7 @@ process predict_ncRNA {
     file 'cm_out' into cmtblouts
 
     """
-    cmsearch --tblout cm_out --cut_ga models.cm chunk
+    cmscan --cpu 1 --tblout cm_out --cut_ga models.cm chunk
     """
 }
 

--- a/annot.nf
+++ b/annot.nf
@@ -393,7 +393,10 @@ process merge_hints {
     """
     touch hints.txt
     cat hints.exon.txt hints.trans.txt > hints.concatenated.txt
-    if [ -s hints.concatenated.txt ] ; then mv hints.concatenated.txt hints.txt; echo -n '--alternatives-from-evidence=false --hintsfile=augustus.hints'; fi
+    if [ -s hints.concatenated.txt ] ; then
+      mv hints.concatenated.txt hints.txt;
+      echo -n '--alternatives-from-evidence=false --hintsfile=augustus.hints';
+    fi
     """
 }
 
@@ -1084,15 +1087,19 @@ if (params.use_reference) {
 
     process make_tree {
         input:
-        file 'tree_selection.fasta' from tree_fasta
+        file 'tree_selection.fasta ' from tree_fasta
 
         output:
         file "tree.out" into tree_out
         file "tree.aln" into tree_aln
 
         """
-        mafft --auto --anysymbol --parttree --quiet tree_selection.fasta > tree.aln
-        FastTree tree.aln > tree.out
+        touch tree.out
+        touch tree.aln
+        if [ -s tree_selection.fasta ] ; then
+          mafft --auto --anysymbol --memsave --retree 1 --parttree --quiet tree_selection.fasta > tree.aln;
+          FastTree tree.aln > tree.out;
+        fi
         """
     }
 

--- a/bin/get_unused_port.sh
+++ b/bin/get_unused_port.sh
@@ -1,0 +1,6 @@
+#!/bin/sh
+
+for port in $(seq 4444 65000); do
+  echo -ne "\035" | telnet 127.0.0.1 $port > /dev/null 2>&1;
+  [ $? -eq 1 ] && echo "$port" && break;
+done

--- a/bin/infernal_to_gff3.lua
+++ b/bin/infernal_to_gff3.lua
@@ -2,7 +2,7 @@
 
 --[[
   Author: Sascha Steinbiss <ss34@sanger.ac.uk>
-  Copyright (c) 2014 Genome Research Ltd
+  Copyright (c) 2014-2015 Genome Research Ltd
 
   Permission to use, copy, modify, and distribute this software for any
   purpose with or without fee is hereby granted, provided that the above
@@ -47,7 +47,7 @@ while true do
     la = split(line, '%s+')
     seqid = la[1]
     seqacc = la[2]
-    qry = la[3]
+    qryid = la[3]
     qryacc = la[4]
     mfrom = la[6]
     mto = la[7]
@@ -63,13 +63,13 @@ while true do
     if strand == '-' then
       sfrom, sto = sto, sfrom
     end
-    print(seqid .. "\tGenomeTools\tgene\t" .. sfrom .. "\t" .. sto .. "\t"
+    print(qryid .. "\tGenomeTools\tgene\t" .. sfrom .. "\t" .. sto .. "\t"
             .. score .. "\t" .. strand .. "\t.\tID=ncRNA" .. i)
-    print(seqid .. "\tINFERNAL\t" .. qry2type(qry) .. "\t" .. sfrom .. "\t"
+    print(qryid .. "\tINFERNAL\t" .. qry2type(seqid) .. "\t" .. sfrom .. "\t"
             .. sto .. "\t" .. score .. "\t" .. strand .. "\t.\tID=ncRNA" .. i
-            .. ":" .. qry2type(qry) .. ";Parent=ncRNA"
-            .. i ..";Name=" .. qry .. ";gc=" .. gc .. ";evalue=" .. evalue
-            ..";score=" .. score ..";model_name=" .. qryacc .. ";model_range="
+            .. ":" .. qry2type(seqid) .. ";Parent=ncRNA"
+            .. i ..";Name=" .. seqid .. ";gc=" .. gc .. ";evalue=" .. evalue
+            ..";score=" .. score ..";model_name=" .. seqacc .. ";model_range="
             .. mfrom .. "-" .. mto)
     i = i + 1
   end

--- a/bin/reaper.sh
+++ b/bin/reaper.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+
+echo $$ > $1.pid
+exec "$@"

--- a/bin/stream_new_against_core.lua
+++ b/bin/stream_new_against_core.lua
@@ -159,26 +159,32 @@ prots[speciesprefix] = nseq
 specseqs[speciesprefix] = ""
 i = 0
 treegenes = io.open("tree_selection.genes", "w+")
+treeclusters = io.open("tree_selection.clusters", "w+")
+treeout = io.open("tree_selection.fasta", "w+")
 for _,cl in ipairs(global_core_clusters) do
   local seen_species = {}
-  for _,m in ipairs(cl.members) do
-    local seq = prots[m[2]][m[1]]
-    if not seen_species[m[2]] and seq then
-      seen_species[m[2]] = true
-      treegenes:write(m[1] .. "\t")
-      specseqs[m[2]] = specseqs[m[2]] .. seq
+  if cl.specidx[speciesprefix] then
+    for _,m in ipairs(cl.members) do
+      local seq = prots[m[2]][m[1]]
+      if not seen_species[m[2]] and seq then
+        seen_species[m[2]] = true
+        treegenes:write(m[1] .. "\t")
+        specseqs[m[2]] = specseqs[m[2]] .. seq
+      end
+    end
+    treegenes:write("\n")
+    treeclusters:write(cl.name .. "\n")
+    i = i + 1
+    if i == 50 then
+      break
     end
   end
-  treegenes:write("\n")
-  i = i + 1
-  if i == 50 then
-    break
-  end
 end
-treeout = io.open("tree_selection.fasta", "w+")
-for s,seq in pairs(specseqs) do
-  treeout:write(">" .. s .. "\n")
-  print_max_width(seq, treeout, 80)
+if i > 0 then
+  for s,seq in pairs(specseqs) do
+    treeout:write(">" .. s .. "\n")
+    print_max_width(seq, treeout, 80)
+  end
 end
 
 -- searching for global core clusters with missing members in new species

--- a/bin/update_references.lua
+++ b/bin/update_references.lua
@@ -338,7 +338,7 @@ for name, values in pairs(refs.species) do
   end
   -- filter out chromosomes
   if file_exists(name .. "/genome.fasta") then
-    local keys, seqs =get_fasta_nosep(name .. "/genome.fasta")
+    local keys, seqs = get_fasta_nosep(name .. "/genome.fasta")
     local outfile = io.open(name .. "/chromosomes.fasta", "w+")
     for hdr, seq in pairs(seqs) do
       if hdr:match(values.chromosome_pattern) then

--- a/loc_travis.config
+++ b/loc_travis.config
@@ -1,5 +1,5 @@
 env {
-    PATH = "${baseDir}/RATT:${baseDir}/ABACAS2:${baseDir}/ORTHOMCLV1.4:${baseDir}/genometools/bin:${baseDir}/aragorn:${baseDir}/augustus/bin:$PATH"
+    PATH = "${baseDir}/RATT:${baseDir}/ABACAS2:${baseDir}/ORTHOMCLV1.4:${baseDir}/genometools/bin:${baseDir}/aragorn:${baseDir}/augustus/bin:${baseDir}/augustus/scripts/$PATH"
     PERL5LIB = "${baseDir}/ORTHOMCLV1.4/:${baseDir}/RATT/:${baseDir}/ABACAS2/:${PERL5LIB}"
     RATT_HOME = "${baseDir}/RATT"
     RATT_CONFIG = "${baseDir}/RATT/RATT.config_euk_NoPseudo_SpliceSite"

--- a/loc_travis.config
+++ b/loc_travis.config
@@ -1,5 +1,5 @@
 env {
-    PATH = "${baseDir}/RATT:${baseDir}/ABACAS2:${baseDir}/ORTHOMCLV1.4:${baseDir}/genometools/bin:${baseDir}/aragorn:${baseDir}/augustus/bin:${baseDir}/augustus/scripts/$PATH"
+    PATH = "${baseDir}/RATT:${baseDir}/ABACAS2:${baseDir}/ORTHOMCLV1.4:${baseDir}/genometools/bin:${baseDir}/aragorn:${baseDir}/augustus/bin:${baseDir}/augustus/scripts/:$PATH"
     PERL5LIB = "${baseDir}/ORTHOMCLV1.4/:${baseDir}/RATT/:${baseDir}/ABACAS2/:${PERL5LIB}"
     RATT_HOME = "${baseDir}/RATT"
     RATT_CONFIG = "${baseDir}/RATT/RATT.config_euk_NoPseudo_SpliceSite"

--- a/test/testdata/infernal.out
+++ b/test/testdata/infernal.out
@@ -1,28 +1,28 @@
 #target name         accession query name           accession mdl mdl from   mdl to seq from   seq to strand trunc pass   gc  bias  score   E-value inc description of target
 #------------------- --------- -------------------- --------- --- -------- -------- -------- -------- ------ ----- ---- ---- ----- ------ --------- --- ---------------------
-Laet.15              -         5S_rRNA              RF00001    cm        1      119   329926   330044      +    no    1 0.50   0.1   95.8   5.1e-20 !   -
-Laet.09              -         5S_rRNA              RF00001    cm        1      119   268259   268141      -    no    1 0.50   0.1   93.0   2.8e-19 !   -
-Laet.09              -         5S_rRNA              RF00001    cm        1      119   400508   400626      +    no    1 0.50   0.1   93.0   2.8e-19 !   -
-Laet.09              -         5S_rRNA              RF00001    cm        1      119   413226   413108      -    no    1 0.50   0.1   93.0   2.8e-19 !   -
-Laet.11              -         5S_rRNA              RF00001    cm        1      119   166516   166398      -    no    1 0.50   0.1   93.0   2.8e-19 !   -
-Laet.11              -         5S_rRNA              RF00001    cm        1      119   390005   390123      +    no    1 0.50   0.1   93.0   2.8e-19 !   -
-Laet.21              -         5S_rRNA              RF00001    cm        1      119   158841   158723      -    no    1 0.50   0.1   93.0   2.8e-19 !   -
-Laet.23              -         5S_rRNA              RF00001    cm        1      119   246720   246602      -    no    1 0.52   0.1   92.5   3.7e-19 !   -
-Laet.05              -         5S_rRNA              RF00001    cm        1      119   404573   404691      +    no    1 0.52   0.1   90.2   1.5e-18 !   -
-Laet.21              -         5S_rRNA              RF00001    cm        1      119   444914   445032      +    no    1 0.51   0.1   88.3   4.4e-18 !   -
-Laet.30              -         5S_rRNA              RF00001    cm        1      119   243716   243636      -    no    1 0.51   0.3   17.9       5.5 !   -
-Laet.31              -         U2                   RF00004    cm        1      192   221603   221457      -    no    1 0.40   1.0   85.6   7.3e-24 !   -
-Laet.24              -         U6                   RF00026    cm        1      106   629923   629826      -    no    1 0.49   0.1   56.5   8.8e-13 !   -
-Laet.19              -         snoTBR5              RF00292    cm        1       96   666864   666952      +    no    1 0.58   0.2  106.3   3.6e-27 !   -
-Laet.19              -         snoTBR17             RF00294    cm        1      288   667052   667337      +    no    1 0.71  36.0   83.3   2.2e-22 !   -
-Laet.19              -         snoTBR7              RF00295    cm        1       75   666693   666765      +    no    1 0.48   0.1   49.8   3.2e-07 !   -
+5S_rRNA              RF00001         Laet.15              -    cm        1      119   329926   330044      +    no    1 0.50   0.1   95.8   5.1e-20 !   -
+5S_rRNA              RF00001         Laet.09              -    cm        1      119   268259   268141      -    no    1 0.50   0.1   93.0   2.8e-19 !   -
+5S_rRNA              RF00001         Laet.09              -    cm        1      119   400508   400626      +    no    1 0.50   0.1   93.0   2.8e-19 !   -
+5S_rRNA              RF00001         Laet.09              -    cm        1      119   413226   413108      -    no    1 0.50   0.1   93.0   2.8e-19 !   -
+5S_rRNA              RF00001         Laet.11              -    cm        1      119   166516   166398      -    no    1 0.50   0.1   93.0   2.8e-19 !   -
+5S_rRNA              RF00001         Laet.11              -    cm        1      119   390005   390123      +    no    1 0.50   0.1   93.0   2.8e-19 !   -
+5S_rRNA              RF00001         Laet.21              -    cm        1      119   158841   158723      -    no    1 0.50   0.1   93.0   2.8e-19 !   -
+5S_rRNA              RF00001         Laet.23              -    cm        1      119   246720   246602      -    no    1 0.52   0.1   92.5   3.7e-19 !   -
+5S_rRNA              RF00001         Laet.05              -    cm        1      119   404573   404691      +    no    1 0.52   0.1   90.2   1.5e-18 !   -
+5S_rRNA              RF00001         Laet.21              -    cm        1      119   444914   445032      +    no    1 0.51   0.1   88.3   4.4e-18 !   -
+5S_rRNA              RF00001         Laet.30              -    cm        1      119   243716   243636      -    no    1 0.51   0.3   17.9       5.5 !   -
+U2              RF00004         Laet.31                   -    cm        1      192   221603   221457      -    no    1 0.40   1.0   85.6   7.3e-24 !   -
+U6              RF00026         Laet.24                   -    cm        1      106   629923   629826      -    no    1 0.49   0.1   56.5   8.8e-13 !   -
+snoTBR5              RF00292         Laet.19              -    cm        1       96   666864   666952      +    no    1 0.58   0.2  106.3   3.6e-27 !   -
+snoTBR17              RF00294         Laet.19             -    cm        1      288   667052   667337      +    no    1 0.71  36.0   83.3   2.2e-22 !   -
+snoTBR7              RF00295         Laet.19              -    cm        1       75   666693   666765      +    no    1 0.48   0.1   49.8   3.2e-07 !   -
 #
 # Program:         cmsearch
 # Version:         1.1rc3 (June 2013)
 # Pipeline mode:   SEARCH
 # Query file:      ./cms/kinetoplastid_rnas.cm
 # Target file:     /lustre/scratch108/parasites/ss34/annot/Laet/ncrna/L_aethiopica.fasta
-# Option settings: /software/pathogen/external/apps/usr/bin/cmsearch --tblout /lustre/scratch108/parasites/ss34/annot/Laet/ncrna/out --cut_ga ./cms/kinetoplastid_rnas.cm /lustre/scratch108/parasites/ss34/annot/Laet/ncrna/L_aethiopica.fasta 
+# Option settings: /software/pathogen/external/apps/usr/bin/cmsearch --tblout /lustre/scratch108/parasites/ss34/annot/Laet/ncrna/out --cut_ga ./cms/kinetoplastid_rnas.cm /lustre/scratch108/parasites/ss34/annot/Laet/ncrna/L_aethiopica.fasta
 # Current dir:     /nfs/users/nfs_s/ss34/annot/Laet/1_rnasearch
 # Date:            Wed Sep  3 09:53:04 2014
 # [ok]


### PR DESCRIPTION
Major changes in this PR:
- Exonerate now runs using pregenerated indexes, substantial speed gain
- fixed gene subset selection for tree building: now checks that core gene clusters in reference also include new species -- this makes tree building more robust if there are only few shared clusters
- do not start tree building if the core set is empty (i.e. no shared genes at all)

The rest are mostly bugfixes and safeguards for weird input. I have also extended the tests to include a little more parameter variation.