### PR TITLE
do not treat lowercase input sequences as repeat masked in LAST

### DIFF
--- a/annot.nf
+++ b/annot.nf
@@ -611,7 +611,7 @@ if (params.do_pseudo) {
         file 'last.out' into pseudochr_last_out
 
         """
-        lastal -pBL80 -F15 -e400 -m10 -f0 prot_index chunk.fasta > last.out
+        lastal -R01 -pBL80 -F15 -e400 -m10 -f0 prot_index chunk.fasta > last.out
         """
     }
 


### PR DESCRIPTION
This PR makes sure that input sequences provided in lowercase form do not get misrecognized as being soft-masked by LAST. This would lead to a total lack of protein-DNA alignments to use as pseudogene candidates.