### PR TITLE
Robustness improvement

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ before_install:
   - sudo rm /etc/dpkg/dpkg.cfg.d/multiarch
 
 install:
-  - sudo apt-get install --yes --force-yes circos build-essential wget fasttree hmmer lua5.1 blast2 ncbi-blast+ unzip cpanminus mummer python-setuptools exonerate snap infernal mafft telnet libboost-iostreams-dev libgsl0ldbl libcolamd2.8.0 libstdc++6
+  - sudo apt-get install --yes --force-yes circos build-essential wget fasttree hmmer lua5.1 blast2 ncbi-blast+ unzip cpanminus mummer python-setuptools exonerate snap infernal mafft netcat libboost-iostreams-dev libgsl0ldbl libcolamd2.8.0 libstdc++6
   - sudo ln -s /usr/bin/fasttree /usr/bin/FastTree
   - sudo test/travis.setup-augustus.sh > /dev/null
   - sudo test/travis.setup-gt.sh > /dev/null

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,7 @@ RUN apt-get update -qq
 RUN apt-get install build-essential hmmer lua5.1 ncbi-blast+ blast2 snap \
                     unzip cpanminus mummer infernal exonerate mafft fasttree \
                     circos libsvg-perl libgd-svg-perl python-setuptools \
-                    libc6-i386 lib32stdc++6 lib32gcc1 telnet \
+                    libc6-i386 lib32stdc++6 lib32gcc1 netcat \
                     last-align libboost-iostreams-dev libgsl0ldbl \
                     libcolamd2.8.0 libstdc++6 --yes --force-yes
 RUN ln -fs /usr/bin/fasttree /usr/bin/FastTree && \

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# annot-nf
+# Companion
 
 A portable, scalable eukaryotic genome annotation pipeline implemented in Nextflow.
 
@@ -44,11 +44,12 @@ For your own runs, provide your own file names, paths, parameters, etc. as defin
 ### [Preparing reference annotations](#reference)
 
 The reference annotations used in the pipeline need to be pre-processed before they can be used.
-TODO: add documentation on how to prepare references.
+See [the HOWTO on the GitHub wiki](https://github.com/sanger-pathogens/annot-nf/wiki/Preparing-reference-data-sets) for more details. There are also pre-generated reference sets for various parasite species/families. Please contact the authors via the email address below to obtain them.
 
 ### [Contact](#contact)
 
 Sascha Steinbiss (ss34@sanger.ac.uk)
 
 ###[Build status](#build)
+
 ![Travis status](https://api.travis-ci.org/sanger-pathogens/annot-nf.svg)

--- a/bin/get_unused_port.sh
+++ b/bin/get_unused_port.sh
@@ -1,6 +1,10 @@
 #!/bin/sh
 
-for port in $(seq 4444 65000); do
-  echo -ne "\035" | telnet 127.0.0.1 $port > /dev/null 2>&1;
+i=1
+while [ "$i" -lt 10 ]; do
+  port=`awk -v min=4444 -v max=65000 'BEGIN{srand(systime() + PROCINFO["pid"]); print int(min+rand()*(max-min+1))}'`;
+  nc -z -w5 127.0.0.1 $port 2>&1;
   [ $? -eq 1 ] && echo "$port" && break;
+  >&2 echo "retrying port $port, try $i"
+  i=`expr $i + 1`
 done

--- a/bin/gff3_to_embl.lua
+++ b/bin/gff3_to_embl.lua
@@ -296,8 +296,8 @@ function embl_vis:visit_feature(fn)
         end
         -- assign colours
         if node:get_type() == "mRNA" and not embl_compliant then
-          local prod = pp:get_attribute("product")
-          if prod then
+          if pp and pp:get_attribute("product") then
+            local prod = pp:get_attribute("product")
             if  prod ~= "term%3Dhypothetical protein" then
               if nof_orths > 0 or prod:match("conserved") then
                 io.write("FT                   /colour=10\n")   -- orange: conserved

--- a/bin/ratt_embl_to_gff3.lua
+++ b/bin/ratt_embl_to_gff3.lua
@@ -85,6 +85,7 @@ for i = 1,#arg do
                           .. e .. ", skipping\n")
           --reset totalrange to disable gene output
           totalrange = nil
+          break
         end
       end
       if totalrange then

--- a/bin/ratt_remove_problematic.lua
+++ b/bin/ratt_remove_problematic.lua
@@ -110,7 +110,9 @@ function flt_stream:next_tree()
   end
   while gn and not self.vis.ok do
     gn = self.instream:next_tree()
-    gn:accept(self.vis)
+    if gn then
+      gn:accept(self.vis)
+    end
   end
   return gn
 end

--- a/bin/split_gff_by_agp.lua
+++ b/bin/split_gff_by_agp.lua
@@ -105,8 +105,7 @@ gff3vis = gt.gff3_visitor_new()
 -- visitor for feature transformation
 visitor = gt.custom_visitor_new()
 function visitor:visit_feature(fn)
-  -- split off potential accession versions
-  local seqid = fn:get_seqid() -- :gsub("%.%d+$","")
+  local seqid = fn:get_seqid()
   -- is this sequence/fragment part of a layout?
   if components[seqid] then
     --print("have components for seqid " .. seqid)


### PR DESCRIPTION
- fail gracefully when facing invalid gene models from RATT
- pick random initial port numbers for exonerate-server instances (this helps avoid race conditions when many jobs look for ports at the same time)